### PR TITLE
chore: harden Renovate config (pinDigests for shared workflows)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Pin digests for supply-chain integrity of shared workflows",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
Pin digests for supply-chain integrity of shared reusable workflows.
No grouping — keep PRs individual so each action bump can be reviewed/tested independently before cascading to consumer repos.