### PR TITLE
feat: add setup-vcpkg composite action with binary caching

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -1,0 +1,62 @@
+name: Setup vcpkg
+description: >
+  Clone and bootstrap vcpkg with working binary caching via actions/cache.
+  Replaces lukka/run-vcpkg whose x-gha binary cache provider was removed
+  from vcpkg in April 2025.
+
+inputs:
+  vcpkg-commit:
+    description: "vcpkg Git commit SHA to checkout"
+    required: true
+  triplet:
+    description: "Target triplet (used in cache key for partition isolation)"
+    required: true
+  token:
+    description: "GitHub token (reserved for future NuGet integration)"
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Clone vcpkg
+      shell: bash
+      run: |
+        set -euo pipefail
+        VCPKG_DIR="${{ github.workspace }}/vcpkg"
+        if [[ ! -d "$VCPKG_DIR/.git" ]]; then
+          git clone https://github.com/microsoft/vcpkg.git "$VCPKG_DIR" --filter=blob:none --no-checkout
+        fi
+        cd "$VCPKG_DIR"
+        git fetch origin "${{ inputs.vcpkg-commit }}" --depth=1
+        git checkout "${{ inputs.vcpkg-commit }}"
+
+    - name: Bootstrap vcpkg (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        "${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+
+    - name: Bootstrap vcpkg (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        & "${{ github.workspace }}\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+
+    - name: Configure environment
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> "$GITHUB_ENV"
+        echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite" >> "$GITHUB_ENV"
+        mkdir -p "${{ github.workspace }}/.vcpkg-binary-cache"
+
+    - name: Restore vcpkg binary cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.vcpkg-binary-cache
+        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
+        restore-keys: |
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -16,3 +16,52 @@ jobs:
         README.md
       skip-vitepress: true # This repo has no real docs to build
       skip-link-check: true # This repo has no local markdown links to check
+
+  test-setup-vcpkg:
+    name: Test setup-vcpkg (${{ matrix.os }}, ${{ matrix.triplet }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            triplet: x64-linux-static
+          - os: windows-2022
+            triplet: x64-windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup vcpkg
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          vcpkg-commit: "66c0373dc7fca549e5803087b9487edfe3aca0a1"
+          triplet: ${{ matrix.triplet }}
+
+      - name: Verify environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "VCPKG_ROOT=$VCPKG_ROOT"
+          echo "VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES"
+          [[ -n "$VCPKG_ROOT" ]] || { echo "FAIL: VCPKG_ROOT not set"; exit 1; }
+          [[ "$VCPKG_BINARY_SOURCES" == *"files,"* ]] || { echo "FAIL: VCPKG_BINARY_SOURCES not configured"; exit 1; }
+          "$VCPKG_ROOT/vcpkg" version
+          [[ -d "${{ github.workspace }}/.vcpkg-binary-cache" ]] || { echo "FAIL: binary cache dir missing"; exit 1; }
+          echo "All checks passed"
+
+      - name: Smoke test — install a small package
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$VCPKG_ROOT/vcpkg" install yaml-cpp --triplet ${{ matrix.triplet }}
+          # Verify binary was cached
+          if ls "${{ github.workspace }}/.vcpkg-binary-cache/"* >/dev/null 2>&1; then
+            echo "OK: binary package cached"
+            ls -la "${{ github.workspace }}/.vcpkg-binary-cache/"
+          else
+            echo "FAIL: no binary packages in cache directory"
+            exit 1
+          fi

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            triplet: x64-linux-static
+            triplet: x64-linux
           - os: windows-2022
             triplet: x64-windows
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Adds a shared composite action at `.github/actions/setup-vcpkg/action.yml` that replaces `lukka/run-vcpkg` across the org.

### Why

`lukka/run-vcpkg@v11` sets `VCPKG_BINARY_SOURCES=clear;x-gha,readwrite`, but vcpkg removed the `x-gha` provider in April 2025 (microsoft/vcpkg-tool#1662). The `clear` also disables the default filesystem cache. Result: **every CI run compiles all vcpkg packages from source** — gRPC alone takes 33–46 minutes.

This affects all 5 C++ repos in the org (provider-sim: 2h50m, anolis: 2h, fluxgraph: 50m, bread/ezo: 22m).

### What this action does

1. Clones vcpkg at a pinned commit (shallow, filter=blob:none)
2. Bootstraps (`bootstrap-vcpkg.sh` on Linux, `.bat` on Windows)
3. Sets `VCPKG_ROOT` and `VCPKG_BINARY_SOURCES=clear;files,...,readwrite`
4. Restores/saves binary cache via `actions/cache@v4`

### Usage (for consuming repos)

```yaml
- name: Setup vcpkg
  uses: anolishq/.github/.github/actions/setup-vcpkg@main
  with:
    vcpkg-commit: ${{ env.VCPKG_COMMIT }}
    triplet: x64-linux-static
```

### Testing

Self-test job added: installs `yaml-cpp` on both Linux and Windows, verifies binary package appears in cache directory.

### Rollout plan

1. This PR (Phase 0) — validate action works
2. Phase 1: Apply to `anolis-provider-bread` (simplest repo)
3. Phase 2: Roll out to ezo → fluxgraph → anolis → provider-sim

### References

- microsoft/vcpkg#45073 — cache fail in GHA (still open)
- lukka/run-vcpkg#251 — x-gha removed (still open)
- microsoft/vcpkg-tool#1662 — PR that removed x-gha