### PR TITLE
fix(setup-vcpkg): reorder steps to prevent hashFiles matching vcpkg ports

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -19,6 +19,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Prepare binary cache directory
+      shell: bash
+      run: mkdir -p "${{ github.workspace }}/.vcpkg-binary-cache"
+
+    - name: Restore vcpkg binary cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.vcpkg-binary-cache
+        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
+        restore-keys: |
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-
+
     - name: Clone vcpkg
       shell: bash
       run: |
@@ -50,13 +63,3 @@ runs:
         set -euo pipefail
         echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> "$GITHUB_ENV"
         echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite" >> "$GITHUB_ENV"
-        mkdir -p "${{ github.workspace }}/.vcpkg-binary-cache"
-
-    - name: Restore vcpkg binary cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/.vcpkg-binary-cache
-        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
-        restore-keys: |
-          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-
-          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-


### PR DESCRIPTION
## Problem

The cache restore step with `hashFiles('**/vcpkg.json', ...)` was positioned AFTER the vcpkg clone step. This means it evaluated against both:
- The project's `vcpkg.json` (intended)
- 2400+ port manifest files in `vcpkg/ports/*/vcpkg.json` (unintended)

This makes the hash computation slow and the key unnecessarily complex. The vcpkg commit is already explicitly part of the cache key, so hashing port manifests is redundant.

## Fix

Move cache restore to be the **first** step (after mkdir). `hashFiles` now evaluates before vcpkg is cloned, so it only matches the consuming project's files.

## Step order (after)

1. Create binary cache directory
2. Restore cache (`hashFiles` evaluates here — only project files exist)
3. Clone vcpkg
4. Bootstrap
5. Set env vars

Caught during Phase 1 review before rolling out to `anolis-provider-bread`.