### PR TITLE
ci: rename workflow to CI, add ok aggregator gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Self Test
+name: CI
 
 on:
   push:
@@ -65,3 +65,19 @@ jobs:
             echo "FAIL: no binary packages in cache directory"
             exit 1
           fi
+
+  ok:
+    name: ok
+    if: always()
+    needs:
+      - docs-check
+      - test-setup-vcpkg
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate job results
+        run: |
+          echo "Job results: ${{ toJSON(needs.*.result) }}"
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
Rename `self-test.yml` → `ci.yml`, set workflow name to `CI`, add `ok` aggregator job.

Once validated, `ok` becomes the sole required status check for branch protection on `main`.