### PR TITLE
feat(setup-vcpkg): derive vcpkg commit from vcpkg-configuration.json baseline

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -4,10 +4,23 @@ description: >
   Replaces lukka/run-vcpkg whose x-gha binary cache provider was removed
   from vcpkg in April 2025.
 
+  By default the vcpkg tool commit is derived from the consuming repo's
+  vcpkg-configuration.json `default-registry.baseline`, so the tool commit
+  and the port baseline are always the same value and cannot drift. Pass
+  `vcpkg-commit` explicitly only to override that (e.g. to pin the tool to a
+  commit different from the port baseline).
+
 inputs:
   vcpkg-commit:
-    description: "vcpkg Git commit SHA to checkout"
-    required: true
+    description: >
+      vcpkg Git commit SHA to checkout. Optional: when empty (the default),
+      it is read from `vcpkg-config`'s default-registry.baseline.
+    required: false
+    default: ""
+  vcpkg-config:
+    description: "Path to vcpkg-configuration.json used to derive the commit when vcpkg-commit is empty."
+    required: false
+    default: "vcpkg-configuration.json"
   triplet:
     description: "Target triplet (used in cache key for partition isolation)"
     required: true
@@ -19,6 +32,29 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve vcpkg commit
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        commit="${{ inputs.vcpkg-commit }}"
+        if [[ -z "$commit" ]]; then
+          cfg="${{ inputs.vcpkg-config }}"
+          if [[ ! -f "$cfg" ]]; then
+            echo "::error::vcpkg-commit not provided and config file not found: $cfg"
+            exit 1
+          fi
+          commit="$(jq -r '."default-registry".baseline // empty' "$cfg")"
+          echo "Derived vcpkg commit from $cfg: $commit"
+        else
+          echo "Using explicit vcpkg-commit input: $commit"
+        fi
+        if [[ -z "$commit" || "$commit" == "null" ]]; then
+          echo "::error::could not resolve a vcpkg commit (input empty and baseline missing in $cfg)"
+          exit 1
+        fi
+        echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
     - name: Prepare binary cache directory
       shell: bash
       run: mkdir -p "${{ github.workspace }}/.vcpkg-binary-cache"
@@ -27,9 +63,9 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ github.workspace }}/.vcpkg-binary-cache
-        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
+        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
         restore-keys: |
-          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ inputs.vcpkg-commit }}-
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-
           vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-
 
     - name: Clone vcpkg
@@ -41,8 +77,8 @@ runs:
           git clone https://github.com/microsoft/vcpkg.git "$VCPKG_DIR" --filter=blob:none --no-checkout
         fi
         cd "$VCPKG_DIR"
-        git fetch origin "${{ inputs.vcpkg-commit }}" --depth=1
-        git checkout "${{ inputs.vcpkg-commit }}"
+        git fetch origin "${{ steps.resolve.outputs.commit }}" --depth=1
+        git checkout "${{ steps.resolve.outputs.commit }}"
 
     - name: Bootstrap vcpkg (Linux/macOS)
       if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,60 @@ jobs:
             exit 1
           fi
 
+  test-setup-vcpkg-derived:
+    name: Test setup-vcpkg derived-commit (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            triplet: x64-linux
+          - os: windows-2022
+            triplet: x64-windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Write a vcpkg-configuration.json fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > vcpkg-configuration.json <<'JSON'
+          {
+            "default-registry": {
+              "kind": "git",
+              "repository": "https://github.com/microsoft/vcpkg",
+              "baseline": "66c0373dc7fca549e5803087b9487edfe3aca0a1"
+            }
+          }
+          JSON
+
+      - name: Setup vcpkg (derive commit from baseline, no vcpkg-commit input)
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: ${{ matrix.triplet }}
+
+      - name: Verify the derived commit matches the baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "$VCPKG_ROOT" ]] || { echo "FAIL: VCPKG_ROOT not set"; exit 1; }
+          head="$(git -C "$VCPKG_ROOT" rev-parse HEAD)"
+          echo "vcpkg HEAD=$head"
+          [[ "$head" == "66c0373dc7fca549e5803087b9487edfe3aca0a1" ]] \
+            || { echo "FAIL: derived commit ($head) != baseline"; exit 1; }
+          echo "OK: vcpkg checked out at the baseline derived from vcpkg-configuration.json"
+
   ok:
     name: ok
     if: always()
     needs:
       - docs-check
       - test-setup-vcpkg
+      - test-setup-vcpkg-derived
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Why

The `setup-vcpkg` action required a `vcpkg-commit` input, which every consumer copy-pasted into a per-workflow `VCPKG_COMMIT` env. That SHA duplicates the value already present in each repo's `vcpkg-configuration.json` → `default-registry.baseline`. The two **must** always be equal (tool commit ↔ port baseline), so maintaining them as two separate copies is pure drift risk and means a future baseline bump touches both the config file *and* N workflow envs.

## What

- `vcpkg-commit` is now **optional**. When omitted, a new `Resolve vcpkg commit` step reads `default-registry.baseline` from `vcpkg-configuration.json` (path configurable via the new `vcpkg-config` input) and uses it for both the binary-cache key and the vcpkg checkout.
- Passing `vcpkg-commit` explicitly still works and overrides the derived value — **all existing callers are unaffected** (backward-compatible).
- Added a `test-setup-vcpkg-derived` CI job (Linux + Windows) that writes a fixture config and exercises the derive path end-to-end (verifies vcpkg checks out at the baseline SHA).

## Result

One source of truth per repo — the `vcpkg-configuration.json` baseline. The tool commit and port baseline can no longer drift, and consumers can drop their `VCPKG_COMMIT` env + `vcpkg-commit:` inputs (follow-up PRs).

## Verification

- YAML validated; backward-compat path preserved by the existing `test-setup-vcpkg` job, new path covered by `test-setup-vcpkg-derived`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)