### PR TITLE
fix(setup-vcpkg): discover vcpkg-configuration.json under workspace

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -38,19 +38,27 @@ runs:
       run: |
         set -euo pipefail
         commit="${{ inputs.vcpkg-commit }}"
-        if [[ -z "$commit" ]]; then
+        if [[ -n "$commit" ]]; then
+          echo "Using explicit vcpkg-commit input: $commit"
+        else
           cfg="${{ inputs.vcpkg-config }}"
+          # The caller may check the repo out under a `path:` subdirectory, so the
+          # config is not necessarily at the workspace root. If the configured path
+          # does not exist, discover it under the workspace (mirrors the cache key's
+          # `**/vcpkg-configuration.json` glob). The vcpkg clone does not exist yet at
+          # this point, but exclude its path defensively.
           if [[ ! -f "$cfg" ]]; then
-            echo "::error::vcpkg-commit not provided and config file not found: $cfg"
+            cfg="$(find "${{ github.workspace }}" -maxdepth 4 -name vcpkg-configuration.json -not -path '*/vcpkg/*' 2>/dev/null | sort | head -1)"
+          fi
+          if [[ -z "$cfg" || ! -f "$cfg" ]]; then
+            echo "::error::vcpkg-commit not provided and no vcpkg-configuration.json found under ${{ github.workspace }}"
             exit 1
           fi
           commit="$(jq -r '."default-registry".baseline // empty' "$cfg")"
           echo "Derived vcpkg commit from $cfg: $commit"
-        else
-          echo "Using explicit vcpkg-commit input: $commit"
         fi
         if [[ -z "$commit" || "$commit" == "null" ]]; then
-          echo "::error::could not resolve a vcpkg commit (input empty and baseline missing in $cfg)"
+          echo "::error::could not resolve a vcpkg commit (input empty and baseline missing/invalid)"
           exit 1
         fi
         echo "commit=$commit" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Write a vcpkg-configuration.json fixture
+      - name: Write a vcpkg-configuration.json fixture in a checkout subdirectory
         shell: bash
         run: |
           set -euo pipefail
-          cat > vcpkg-configuration.json <<'JSON'
+          # Real consumers check their repo out under a `path:` subdir, so the
+          # config is NOT at the workspace root — the action must discover it.
+          mkdir -p consumer-repo
+          cat > consumer-repo/vcpkg-configuration.json <<'JSON'
           {
             "default-registry": {
               "kind": "git",
@@ -97,7 +100,7 @@ jobs:
           }
           JSON
 
-      - name: Setup vcpkg (derive commit from baseline, no vcpkg-commit input)
+      - name: Setup vcpkg (derive commit from baseline in subdir, no vcpkg-commit input)
         uses: ./.github/actions/setup-vcpkg
         with:
           triplet: ${{ matrix.triplet }}


### PR DESCRIPTION
## Why

Follow-up to #21. The derive-from-baseline path failed on real consumers (e.g. anolis-provider-ezo#23) with `config file not found: vcpkg-configuration.json`. Consumers check their repo out under a `path:` subdirectory, and **composite-action `run` steps execute from `$GITHUB_WORKSPACE`** — they do not inherit the caller step's `working-directory`. So the config is not at the path the resolve step assumed. The original self-test wrote its fixture at the workspace root, so it missed this.

## What

- When `vcpkg-commit` is empty and the configured `vcpkg-config` path doesn't exist, **discover** `vcpkg-configuration.json` under `$GITHUB_WORKSPACE` via `find` (mirrors the cache key's `**/vcpkg-configuration.json` glob), excluding the vcpkg clone path. An explicit `vcpkg-config` still takes precedence.
- Update the `test-setup-vcpkg-derived` job to write its fixture in a **subdirectory** (`consumer-repo/`), reproducing the real consumer layout so this regression is caught here going forward.

## Verification

- YAML validated; discovery logic simulated locally against the real subdir layout (resolves the correct baseline). The updated subdir self-test exercises it on Linux + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)