### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo.
+* @CameronBrooks11


### PR DESCRIPTION
Adds `.github/CODEOWNERS` (`* @CameronBrooks11`) so the repo satisfies the baseline `codeowners_exists` check and is ready to route ownership as the org grows. Part of adopting baseliner across the anolishq org.