### PR TITLE
chore: onboard baseliner-control into branch protection

### DIFF
--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -46,6 +46,7 @@ REPOS=(
   anolis-telemetry-export
   anolis-workbench
   anolishq.github.io
+  baseliner-control
   fluxgraph
   renovate-config
 )


### PR DESCRIPTION
Adds `baseliner-control` to the `REPOS` list in `scripts/apply-branch-protection.sh`.

The repo now exposes the shared `ok` aggregator check (anolishq/baseliner-control#6 — CI green on PRs), so it can carry the canonical classic `main` protection like every other repo. This brings coverage to **all 14** org repos.

After merge, `./scripts/apply-branch-protection.sh` is run to apply protection to baseliner-control (idempotent no-op on the other 13).