### PR TITLE
feat: finalize vcpkg dependency CVE scan (OOM fix, NVD source, safe-without-key)

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -118,9 +118,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/cve-bin-tool
-          key: cve-bin-tool-db-${{ github.run_id }}
+          key: cve-bin-tool-db-v2-${{ github.run_id }}
           restore-keys: |
-            cve-bin-tool-db-
+            cve-bin-tool-db-v2-
 
       - name: Build dependency list from vcpkg SBOM
         id: deps
@@ -202,7 +202,9 @@ jobs:
           # Trim the CVE DB to NVD (CPE matching) + RedHat + PURL2CPE. The OSV
           # source in particular pulls every language ecosystem and bloated the
           # DB build until the runner was OOM-reclaimed; we match C/C++ by CPE.
-          common=("${NVD_ARGS[@]}" --no-0-cve-report --format json,html
+          # -u now forces a fresh NVD fetch each run (and self-heals a partial
+          # cached DB); on a warm cache it's an incremental delta, so cheap.
+          common=("${NVD_ARGS[@]}" -u now --no-0-cve-report --format json,html
                   --disable-data-source "OSV,GAD,CURL,EPSS,RSD")
           # 1) Version-based lookup of the resolved direct deps against the FULL
           #    NVD database — covers C++ libs with no binary checker (protobuf,

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -118,9 +118,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/cve-bin-tool
-          key: cve-bin-tool-db-v2-${{ github.run_id }}
+          key: cve-bin-tool-db-v3-${{ github.run_id }}
           restore-keys: |
-            cve-bin-tool-db-v2-
+            cve-bin-tool-db-v3-
 
       - name: Build dependency list from vcpkg SBOM
         id: deps
@@ -202,9 +202,7 @@ jobs:
           # Trim the CVE DB to NVD (CPE matching) + RedHat + PURL2CPE. The OSV
           # source in particular pulls every language ecosystem and bloated the
           # DB build until the runner was OOM-reclaimed; we match C/C++ by CPE.
-          # -u now forces a fresh NVD fetch each run (and self-heals a partial
-          # cached DB); on a warm cache it's an incremental delta, so cheap.
-          common=("${NVD_ARGS[@]}" -u now --no-0-cve-report --format json,html
+          common=("${NVD_ARGS[@]}" --no-0-cve-report --format json,html
                   --disable-data-source "OSV,GAD,CURL,EPSS,RSD")
           # 1) Version-based lookup of the resolved direct deps against the FULL
           #    NVD database — covers C++ libs with no binary checker (protobuf,

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -171,6 +171,10 @@ jobs:
               gh.write(f"count={len(rows)}\n")
           PY
 
+      - name: (DEBUG PROBE) add known-vulnerable openssl row
+        working-directory: ${{ inputs.manifest-dir }}
+        run: echo "openssl,openssl,1.0.1g" >> deps.csv
+
       - name: Run CVE scan (non-blocking)
         id: scan
         working-directory: ${{ inputs.manifest-dir }}

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -64,6 +64,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build g++ pkg-config
 
+      - name: Add swap space
+        # cve-bin-tool's CVE-database build is memory-heavy and was OOM-killing
+        # the standard runner mid-build (job reclaimed). Give the kernel headroom.
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
@@ -177,7 +187,11 @@ jobs:
           else
             NVD_ARGS=(--nvd json-mirror)
           fi
-          common=("${NVD_ARGS[@]}" --no-0-cve-report --format json,html)
+          # Trim the CVE DB to NVD (CPE matching) + RedHat + PURL2CPE. The OSV
+          # source in particular pulls every language ecosystem and bloated the
+          # DB build until the runner was OOM-reclaimed; we match C/C++ by CPE.
+          common=("${NVD_ARGS[@]}" --no-0-cve-report --format json,html
+                  --disable-data-source "OSV,GAD,CURL,EPSS,RSD")
           # 1) Version-based lookup of the resolved direct deps against the FULL
           #    NVD database — covers C++ libs with no binary checker (protobuf,
           #    yaml-cpp, grpc). Runs first so it seeds the cached CVE DB.

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -64,14 +64,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build g++ pkg-config
 
-      - name: Add swap space
+      - name: Maximize swap space
         # cve-bin-tool's CVE-database build is memory-heavy and was OOM-killing
-        # the standard runner mid-build (job reclaimed). Give the kernel headroom.
+        # the standard runner mid-build (job reclaimed). Give the kernel headroom
+        # via a large swapfile on the roomy /mnt disk. Best-effort: never blocks.
+        continue-on-error: true
         run: |
-          sudo fallocate -l 8G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          sudo swapoff -a || true
+          sudo rm -f /swapfile /mnt/swapfile || true
+          sudo fallocate -l 10G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
           free -h
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -193,7 +193,11 @@ jobs:
           if [ -n "${NVD_API_KEY:-}" ]; then
             NVD_ARGS=(--nvd api2 --nvd-api-key "$NVD_API_KEY")
           else
-            NVD_ARGS=(--nvd json-mirror)
+            # json-mirror pulls NVD from a GCS bucket via gsutil and loads
+            # nothing without GCS auth (silent: DB ends up RedHat-only). The
+            # direct NVD API is keyless — rate-limited/slower but actually
+            # populates the full NVD CPE data we match against.
+            NVD_ARGS=(--nvd api2)
           fi
           # Trim the CVE DB to NVD (CPE matching) + RedHat + PURL2CPE. The OSV
           # source in particular pulls every language ecosystem and bloated the

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -42,7 +42,7 @@ on:
         type: string
     secrets:
       nvd-api-key:
-        description: "Optional NVD API key (faster CVE DB updates; not required — the default cveb.in mirror needs no key)."
+        description: "NVD API key (free from nvd.nist.gov). Strongly recommended: without it the NVD dataset does not load and CVE coverage is incomplete (the summary flags this)."
         required: false
 
 permissions:
@@ -171,10 +171,6 @@ jobs:
               gh.write(f"count={len(rows)}\n")
           PY
 
-      - name: (DEBUG PROBE) add known-vulnerable openssl row
-        working-directory: ${{ inputs.manifest-dir }}
-        run: echo "openssl,openssl,1.0.1g" >> deps.csv
-
       - name: Run CVE scan (non-blocking)
         id: scan
         working-directory: ${{ inputs.manifest-dir }}
@@ -187,18 +183,23 @@ jobs:
           DEP_COUNT: ${{ steps.deps.outputs.count }}
         run: |
           set +e
-          # Without an NVD API key the keyless NVD API is heavily rate-limited
-          # (the DB download runs for ages); the keyless json-mirror is fast.
-          # With a key, use the authenticated api2 source.
+          # NVD source selection. The full NVD CPE dataset is what makes the
+          # C/C++ version lookup meaningful, and getting it reliably needs an
+          # NVD API key:
+          #   * with a key -> the authenticated api2 source (fast, complete);
+          #   * without a key -> json-mirror (keyless, never rate-limited, but
+          #     in practice loads only the RedHat feed here, so NVD coverage is
+          #     INCOMPLETE — the summary flags this loudly). Keyless api2 is not
+          #     used because NVD rate-limits/4xx's anonymous requests and crashes
+          #     the run.
           if [ -n "${NVD_API_KEY:-}" ]; then
             NVD_ARGS=(--nvd api2 --nvd-api-key "$NVD_API_KEY")
+            HAS_KEY=true
           else
-            # json-mirror pulls NVD from a GCS bucket via gsutil and loads
-            # nothing without GCS auth (silent: DB ends up RedHat-only). The
-            # direct NVD API is keyless — rate-limited/slower but actually
-            # populates the full NVD CPE data we match against.
-            NVD_ARGS=(--nvd api2)
+            NVD_ARGS=(--nvd json-mirror)
+            HAS_KEY=false
           fi
+          echo "has_key=$HAS_KEY" >> "$GITHUB_OUTPUT"
           # Trim the CVE DB to NVD (CPE matching) + RedHat + PURL2CPE. The OSV
           # source in particular pulls every language ecosystem and bloated the
           # DB build until the runner was OOM-reclaimed; we match C/C++ by CPE.
@@ -228,9 +229,12 @@ jobs:
       - name: Build job summary
         if: always()
         working-directory: ${{ inputs.manifest-dir }}
+        env:
+          HAS_KEY: ${{ steps.scan.outputs.has_key }}
         run: |
           python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json, os
+          has_key = os.environ.get("HAS_KEY", "") == "true"
           def load(path):
               if not os.path.exists(path):
                   return None
@@ -250,6 +254,16 @@ jobs:
                   out.append(f"\n…and {len(rows) - 100} more — see the report artifact.")
               return "\n".join(out)
           print("## vcpkg dependency CVE scan\n")
+          if not has_key:
+              # No key -> NVD did not load, so an empty result is NOT a clean
+              # bill of health. Make that unmistakable.
+              print("> [!WARNING]\n"
+                    "> **`NVD_API_KEY` is not configured, so the NVD dataset did "
+                    "not load — CVE coverage is INCOMPLETE.**\n"
+                    "> An empty result below does **not** mean the dependencies "
+                    "are free of known CVEs. Add a (free) NVD API key as the "
+                    "`NVD_API_KEY` secret to enable full coverage. "
+                    "See the dependency-scanning docs in `anolishq/.github`.\n")
           for title, path in [
               ("Direct dependencies (resolved version → NVD)", "cve-deps.json"),
               ("Binary scan (linked / transitive libraries)", "cve-binary.json"),
@@ -260,7 +274,8 @@ jobs:
                   print("_No report produced (scan skipped or errored — see step log)._\n")
                   continue
               if not rows:
-                  print("✅ No known CVEs detected.\n")
+                  print(("✅ No known CVEs detected.\n" if has_key
+                         else "_No CVEs reported — but NVD did not load (see warning above)._\n"))
                   continue
               by_sev = {}
               for r in rows:


### PR DESCRIPTION
Part of **anolishq/.github#28**. Finalizes the reusable `dependency-scan.yml` after extensive canary-driven debugging. Squash of the experiment branch.

### What this fixes (all found on the anolis canary)
1. **OOM reclaim** — cve-bin-tool's multi-source DB build (esp. OSV, which pulls every language ecosystem) exhausted the runner and it was reclaimed mid-build. Fix: `--disable-data-source OSV,GAD,CURL,EPSS,RSD` (we match C/C++ by CPE via NVD) + a 10G swapfile on `/mnt`.
2. **NVD data not loading** — `--nvd json-mirror` (cve-bin-tool's keyless default) silently loads only the RedHat feed here (its GCS snapshot doesn't populate), and keyless `api2` is rate-limited/4xx'd by NVD and crashes. **Reliable NVD coverage needs a free NVD API key.**

### NVD source behaviour
- **With `NVD_API_KEY` secret** → authenticated `api2` (fast, complete NVD). *This is the required production config.*
- **Without a key** → keyless `json-mirror` (graceful, but NVD-incomplete). The job summary shows a **loud INCOMPLETE warning** so an empty result is never mistaken for a clean bill of health.

### Coverage approach (unchanged, validated)
Resolved versions from the vcpkg SPDX SBOMs → curated `vcpkg-port → NVD vendor/product` map (names verified against NVD's CPE dictionary) → cve-bin-tool `--input-file` (full-NVD, any product) **plus** the binary scan (linked/transitive libs). Non-blocking; schedule + dispatch.

**⚠️ Action required for real coverage:** add a free NVD API key (https://nvd.nist.gov/developers/request-an-api-key) as the org/repo secret `NVD_API_KEY`. Until then scans run but report INCOMPLETE.