### PR TITLE
fix: reusable secret name nvd-api-key -> nvd_api_key (hyphen expression bug)

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -41,7 +41,7 @@ on:
         default: "3.4"
         type: string
     secrets:
-      nvd-api-key:
+      nvd_api_key:
         description: "NVD API key (free from nvd.nist.gov). Strongly recommended: without it the NVD dataset does not load and CVE coverage is incomplete (the summary flags this)."
         required: false
 
@@ -179,7 +179,7 @@ jobs:
         # having the whole job reclaimed.
         timeout-minutes: 45
         env:
-          NVD_API_KEY: ${{ secrets.nvd-api-key }}
+          NVD_API_KEY: ${{ secrets.nvd_api_key }}
           DEP_COUNT: ${{ steps.deps.outputs.count }}
         run: |
           set +e

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
       triplet: x64-linux-static   # x64-linux for repos using the built-in triplet
       # features: "tests;json;yaml;server"   # only if deps are feature-gated
     secrets:
-      nvd-api-key: ${{ secrets.NVD_API_KEY }}
+      nvd_api_key: ${{ secrets.NVD_API_KEY }}
 ```
 
 ### Required: `NVD_API_KEY`


### PR DESCRIPTION
Part of **anolishq/.github#28**. The NVD key was reaching repos but arriving **empty inside the reusable workflow** — `${{ secrets.nvd-api-key }}` parses the hyphens as subtraction (`secrets.nvd - api - key`) → empty, so scans ran keyless and NVD returned 403. Renamed the secret input to `nvd_api_key` (underscores) so dot-access works. Diagnosed with a length probe (key reaches the repo at length 36, empty through the reusable). Callers updated to match.