### PR TITLE
chore: track internal refs via @v2 + document versioning

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -79,7 +79,7 @@ jobs:
           python-version: "3.12"
 
       - name: Setup vcpkg
-        uses: anolishq/.github/.github/actions/setup-vcpkg@82e7f70687b6b2b3cc8a9b047a397c73283b0428 # main
+        uses: anolishq/.github/.github/actions/setup-vcpkg@e993ae623cdaebfaef4e4a25ac806f269a6a2f86 # v2
         with:
           triplet: ${{ inputs.triplet }}
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Org-level shared workflows and configuration for all anolishq repositories.
 
+## Versioning
+
+Consumers pin these shared workflows/actions to a commit SHA tagged **`v2`**:
+
+```yaml
+uses: anolishq/.github/.github/actions/setup-vcpkg@<sha> # v2
+```
+
+The `# v2` comment tells Renovate to track the **`v2` tag** — so a pin only
+moves when `v2` is deliberately re-tagged (a release), **not** on every push to
+`main`. Do **not** pin internal refs to `@<sha> # main`: that makes Renovate
+re-pin on every `.github` commit, which churns PRs across the org.
+
+**Cutting a release:** for a backward-compatible change, move the `v2` tag to
+the new `main` SHA (`git tag -f v2 <sha> && git push -f origin v2`); for a
+breaking change, cut `v3` and migrate consumers. Renovate then bumps the
+SHA-pins to the new tag SHA (held 3 days by the supply-chain soak).
+
 ## Reusable Workflows
 
 ### docs-check.yml


### PR DESCRIPTION
Part of **anolishq/.github#36**. Converts the `.github` self-ref (`setup-vcpkg`) from `# main` to `# v2`, and adds a **Versioning** section to the README documenting the convention (pin `@<sha> # v2`, move the `v2` tag on releases, never `# main`). The `v2` tag has been moved to the current HEAD. Companion PRs convert the consumer repos.