### PR TITLE
fix: docs VitePress build broken by pnpm 11 (esbuild build skipped)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -76,7 +76,7 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
-          version: 11
+          version: 9
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -95,6 +95,13 @@ jobs:
             "pnpm": { "onlyBuiltDependencies": ["esbuild"] }
           }
           EOF
+          # pnpm 10.6+/11 reads onlyBuiltDependencies from pnpm-workspace.yaml,
+          # not package.json's "pnpm" field — without this, pnpm skips esbuild's
+          # build script and the vitepress build fails (ERR_PNPM_IGNORED_BUILDS).
+          cat > pnpm-workspace.yaml << 'EOF'
+          onlyBuiltDependencies:
+            - esbuild
+          EOF
           cat > docs/.vitepress/config.mts << 'EOF'
           import { defineConfig } from 'vitepress'
           export default defineConfig({

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -95,13 +95,6 @@ jobs:
             "pnpm": { "onlyBuiltDependencies": ["esbuild"] }
           }
           EOF
-          # pnpm 10.6+/11 reads onlyBuiltDependencies from pnpm-workspace.yaml,
-          # not package.json's "pnpm" field — without this, pnpm skips esbuild's
-          # build script and the vitepress build fails (ERR_PNPM_IGNORED_BUILDS).
-          cat > pnpm-workspace.yaml << 'EOF'
-          onlyBuiltDependencies:
-            - esbuild
-          EOF
           cat > docs/.vitepress/config.mts << 'EOF'
           import { defineConfig } from 'vitepress'
           export default defineConfig({


### PR DESCRIPTION
The shared `docs-check.yml` VitePress build regressed: `pnpm/action-setup` pulls **pnpm 11**, which no longer runs esbuild's build script from `package.json`'s `pnpm.onlyBuiltDependencies` → `ERR_PNPM_IGNORED_BUILDS` → vitepress build fails. Hit anolis-protocol (passed 05-25, broke today) and anolis-workbench; latent org-wide. **Fix:** pin the scaffold to pnpm 9 (runs build scripts by default). Validated end-to-end against anolis-protocol's docs — VitePress build green.