### PR TITLE
feat: reusable libFuzzer fuzz scaffold

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,7 +1,7 @@
 name: Fuzz
 
 # Reusable libFuzzer runner for the org's C/C++ repos. Builds a repo's fuzz
-# targets with Clang (`-fsanitize=fuzzer,address,undefined`, via the shared
+# targets with Clang (`-fsanitize=fuzzer,address`, via the shared
 # AddFuzzTarget.cmake helper + an `ENABLE_FUZZING` fuzz preset) and runs each
 # for a bounded time against its checked-in corpus.
 #

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,156 @@
+name: Fuzz
+
+# Reusable libFuzzer runner for the org's C/C++ repos. Builds a repo's fuzz
+# targets with Clang (`-fsanitize=fuzzer,address,undefined`, via the shared
+# AddFuzzTarget.cmake helper + an `ENABLE_FUZZING` fuzz preset) and runs each
+# for a bounded time against its checked-in corpus.
+#
+# This is a short *regression* run (re-exercise the corpus + a brief fuzz),
+# not a soak — keep `max-total-time` small. Advisory by default (surfaces
+# crashes in the summary + a `fuzz-crashes` artifact); set `enforce: true`
+# to fail the job when a target crashes.
+
+on:
+  workflow_call:
+    inputs:
+      triplet:
+        description: "vcpkg triplet (cache key)."
+        required: false
+        default: "x64-linux-static"
+        type: string
+      build-preset:
+        description: "CMake fuzz preset (Clang + ENABLE_FUZZING=ON)."
+        required: true
+        type: string
+      fuzz-binaries:
+        description: "Space-separated paths to the built fuzz target binaries (relative to manifest-dir)."
+        required: true
+        type: string
+      corpus-root:
+        description: "Directory holding per-target corpora (subdir per binary basename)."
+        required: false
+        default: "fuzz/corpus"
+        type: string
+      max-total-time:
+        description: "Seconds to run each fuzz target."
+        required: false
+        default: "60"
+        type: string
+      enforce:
+        description: "Fail the job when a target crashes (default: advisory only)."
+        required: false
+        default: false
+        type: boolean
+      manifest-dir:
+        description: "Directory containing vcpkg.json / the CMake project root."
+        required: false
+        default: "."
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # Build the whole toolchain (vcpkg deps + project) with Clang so the
+  # code-under-test is instrumented consistently with the harness.
+  CC: clang
+  CXX: clang++
+
+jobs:
+  fuzz:
+    name: fuzz
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm ninja-build pkg-config
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup vcpkg
+        uses: anolishq/.github/.github/actions/setup-vcpkg@fe0a8fce045364cb2e3552a7fbca59263395c8d6 # v2
+        with:
+          triplet: ${{ inputs.triplet }}
+
+      - name: Configure
+        working-directory: ${{ inputs.manifest-dir }}
+        run: cmake --preset "${{ inputs.build-preset }}"
+
+      - name: Build fuzz targets
+        working-directory: ${{ inputs.manifest-dir }}
+        run: cmake --build --preset "${{ inputs.build-preset }}" --parallel
+
+      - name: Run fuzz targets
+        id: fuzz
+        working-directory: ${{ inputs.manifest-dir }}
+        env:
+          BINARIES: ${{ inputs.fuzz-binaries }}
+          CORPUS_ROOT: ${{ inputs.corpus-root }}
+          MAX_TIME: ${{ inputs.max-total-time }}
+        run: |
+          set +e
+          mkdir -p fuzz-crashes
+          crashed=0
+          for bin in $BINARIES; do
+            if [ ! -x "$bin" ]; then
+              echo "::error::fuzz binary not found or not executable: $bin"
+              crashed=$((crashed+1)); continue
+            fi
+            name=$(basename "$bin")
+            corpus="$CORPUS_ROOT/$name"
+            mkdir -p "$corpus"
+            echo "::group::$name (max_total_time=${MAX_TIME}s, corpus=$corpus)"
+            "$bin" -max_total_time="$MAX_TIME" -print_final_stats=1 \
+              -artifact_prefix="fuzz-crashes/${name}-" "$corpus"
+            rc=$?
+            echo "::endgroup::"
+            echo "$name exit code: $rc"
+            if [ "$rc" -ne 0 ]; then
+              crashed=$((crashed+1))
+              echo "::warning::fuzz target '$name' exited $rc (crash/leak — see fuzz-crashes artifact)"
+            fi
+          done
+          echo "crashed=$crashed" >> "$GITHUB_OUTPUT"
+
+      - name: Build job summary
+        if: always()
+        working-directory: ${{ inputs.manifest-dir }}
+        env:
+          CRASHED: ${{ steps.fuzz.outputs.crashed }}
+        run: |
+          {
+            echo "## Fuzz run"
+            echo ""
+            n=$(find fuzz-crashes -type f 2>/dev/null | wc -l)
+            if [ "${CRASHED:-0}" -gt 0 ] || [ "$n" -gt 0 ]; then
+              echo "⚠️ **${CRASHED:-0} target(s) crashed**, ${n} reproducer(s) captured (see the \`fuzz-crashes\` artifact)."
+            else
+              echo "✅ No crashes — all targets survived the regression run."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload crashes
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: fuzz-crashes
+          path: ${{ inputs.manifest-dir }}/fuzz-crashes
+          if-no-files-found: ignore
+
+      - name: Enforce (optional)
+        if: ${{ inputs.enforce }}
+        env:
+          CRASHED: ${{ steps.fuzz.outputs.crashed }}
+        run: |
+          if [ "${CRASHED:-0}" -gt 0 ]; then
+            echo "::error::fuzz: ${CRASHED} target(s) crashed (enforce=true)"
+            exit 1
+          fi
+          echo "fuzz clean (enforce=true)"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,35 @@ the artifact contains ready-to-paste suppression blocks. Only **"definitely
 lost"** is treated as a failure; "possibly lost" / "still reachable" (library
 static/TLS allocations) are reported but ignored.
 
+### fuzz.yml
+
+Reusable [libFuzzer](https://llvm.org/docs/LibFuzzer.html) runner for the C/C++
+repos. Builds a repo's fuzz targets with **Clang**
+(`-fsanitize=fuzzer,address,undefined`) and runs each for a bounded time against
+its checked-in corpus. This is a short **regression** run, not a soak — keep
+`max-total-time` small. Advisory by default (crashes surface in the summary + a
+`fuzz-crashes` artifact); `enforce: true` fails on a crash.
+
+Two pieces:
+
+1. **`templates/AddFuzzTarget.cmake`** — copy into the consumer repo (e.g.
+   `cmake/AddFuzzTarget.cmake`), gate behind `option(ENABLE_FUZZING ...)`, and
+   declare targets with `anolis_add_fuzz_target(NAME ... SOURCES ... LINK ...)`.
+   A harness only defines `LLVMFuzzerTestOneInput`; libFuzzer provides `main()`.
+2. **A `ci-fuzz` CMake preset** (Clang + `ENABLE_FUZZING=ON`) the workflow configures.
+
+```yaml
+jobs:
+  fuzz:
+    uses: anolishq/.github/.github/workflows/fuzz.yml@<sha> # v2
+    with:
+      build-preset: ci-fuzz
+      fuzz-binaries: "build/ci-fuzz/fuzz/fuzz_config build/ci-fuzz/fuzz/fuzz_frame"
+      corpus-root: fuzz/corpus      # per-target subdir by binary basename
+      max-total-time: "60"          # seconds per target
+      # enforce: true               # fail on crash
+```
+
 ## Shared Configuration
 
 ### .markdownlint.json

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ static/TLS allocations) are reported but ignored.
 
 Reusable [libFuzzer](https://llvm.org/docs/LibFuzzer.html) runner for the C/C++
 repos. Builds a repo's fuzz targets with **Clang**
-(`-fsanitize=fuzzer,address,undefined`) and runs each for a bounded time against
+(`-fsanitize=fuzzer,address`) and runs each for a bounded time against
 its checked-in corpus. This is a short **regression** run, not a soak — keep
 `max-total-time` small. Advisory by default (crashes surface in the summary + a
 `fuzz-crashes` artifact); `enforce: true` fails on a crash.

--- a/templates/AddFuzzTarget.cmake
+++ b/templates/AddFuzzTarget.cmake
@@ -10,8 +10,8 @@
 #     anolis_add_fuzz_target(NAME fuzz_config SOURCES fuzz/fuzz_config.cpp LINK anolis-core)
 #   endif()
 #
-# Each target is an executable built with `-fsanitize=fuzzer,address` (+ UBSan,
-# debug info, frame pointers). libFuzzer provides `main()`, so the harness only
+# Each target is an executable built with `-fsanitize=fuzzer,address` (debug
+# info, frame pointers). libFuzzer provides `main()`, so the harness only
 # defines `LLVMFuzzerTestOneInput`. Run locally with:
 #
 #   ./fuzz_config -max_total_time=60 fuzz/corpus/fuzz_config
@@ -31,14 +31,17 @@ endif()
 
 # Sanitizer set shared by every fuzz target. fuzzer-no-link instruments code for
 # coverage without pulling libFuzzer's main() into non-target objects.
+#
+# IMPORTANT: include() this BEFORE add_subdirectory() of the code-under-test so
+# the instrumentation below applies to it, not just the harness.
 set(ANOLIS_FUZZ_FLAGS
   -g -O1 -fno-omit-frame-pointer
-  -fsanitize=fuzzer-no-link,address,undefined)
+  -fsanitize=fuzzer-no-link,address)
 
 # Apply coverage+sanitizer instrumentation to the whole build so the
 # code-under-test (not just the harness) is instrumented.
 add_compile_options(${ANOLIS_FUZZ_FLAGS})
-add_link_options(-fsanitize=address,undefined)
+add_link_options(-fsanitize=address)
 
 # anolis_add_fuzz_target(NAME <name> SOURCES <src>... [LINK <lib>...])
 function(anolis_add_fuzz_target)

--- a/templates/AddFuzzTarget.cmake
+++ b/templates/AddFuzzTarget.cmake
@@ -1,0 +1,56 @@
+# AddFuzzTarget.cmake — shared libFuzzer target helper for the anolishq C/C++ repos.
+#
+# Copy this file into a consumer repo (e.g. `cmake/AddFuzzTarget.cmake`) and
+# `include()` it. Gate fuzzing behind `option(ENABLE_FUZZING ...)` so normal
+# builds are unaffected:
+#
+#   option(ENABLE_FUZZING "Build libFuzzer fuzz targets (requires clang)" OFF)
+#   if(ENABLE_FUZZING)
+#     include(cmake/AddFuzzTarget.cmake)
+#     anolis_add_fuzz_target(NAME fuzz_config SOURCES fuzz/fuzz_config.cpp LINK anolis-core)
+#   endif()
+#
+# Each target is an executable built with `-fsanitize=fuzzer,address` (+ UBSan,
+# debug info, frame pointers). libFuzzer provides `main()`, so the harness only
+# defines `LLVMFuzzerTestOneInput`. Run locally with:
+#
+#   ./fuzz_config -max_total_time=60 fuzz/corpus/fuzz_config
+#
+# The reusable `fuzz.yml` workflow builds and runs these in CI.
+
+if(NOT ENABLE_FUZZING)
+  return()
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  message(FATAL_ERROR
+    "ENABLE_FUZZING requires a Clang toolchain (libFuzzer). "
+    "Current compiler: ${CMAKE_CXX_COMPILER_ID}. "
+    "Configure with -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++.")
+endif()
+
+# Sanitizer set shared by every fuzz target. fuzzer-no-link instruments code for
+# coverage without pulling libFuzzer's main() into non-target objects.
+set(ANOLIS_FUZZ_FLAGS
+  -g -O1 -fno-omit-frame-pointer
+  -fsanitize=fuzzer-no-link,address,undefined)
+
+# Apply coverage+sanitizer instrumentation to the whole build so the
+# code-under-test (not just the harness) is instrumented.
+add_compile_options(${ANOLIS_FUZZ_FLAGS})
+add_link_options(-fsanitize=address,undefined)
+
+# anolis_add_fuzz_target(NAME <name> SOURCES <src>... [LINK <lib>...])
+function(anolis_add_fuzz_target)
+  cmake_parse_arguments(FZ "" "NAME" "SOURCES;LINK" ${ARGN})
+  if(NOT FZ_NAME OR NOT FZ_SOURCES)
+    message(FATAL_ERROR "anolis_add_fuzz_target: NAME and SOURCES are required")
+  endif()
+  add_executable(${FZ_NAME} ${FZ_SOURCES})
+  # The target itself links libFuzzer (provides main()).
+  target_compile_options(${FZ_NAME} PRIVATE -fsanitize=fuzzer)
+  target_link_options(${FZ_NAME} PRIVATE -fsanitize=fuzzer)
+  if(FZ_LINK)
+    target_link_libraries(${FZ_NAME} PRIVATE ${FZ_LINK})
+  endif()
+endfunction()


### PR DESCRIPTION
Closes **#53** · part of CI-hardening epic **#54**.

Shared fuzzing scaffold for the C/C++ repos:
- **`templates/AddFuzzTarget.cmake`** — copy-in CMake helper; `anolis_add_fuzz_target(NAME … SOURCES … LINK …)` builds a libFuzzer executable, instrumenting the code-under-test with `-fsanitize=fuzzer,address` (include before `add_subdirectory` of the target).
- **`.github/workflows/fuzz.yml`** — reusable runner: builds a repo's `ci-fuzz` preset with Clang and runs each target bounded against its checked-in corpus. Advisory by default (crashes → summary + `fuzz-crashes` artifact); `enforce: true` fails on crash.
- README documents both pieces.

**Validated end-to-end against anolis** with a real `fuzz_config` target (YAML `load_config`): Clang build of the runtime + all vcpkg deps succeeded, the harness instrumented the code (`INITED cov: 1544`, coverage grew to 1713 as it discovered inputs), 30s run, **no crashes**. The anolis target itself lands separately under #48.