### PR TITLE
fix(docs): use npm for VitePress build check (stop pnpm build-script churn)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -74,10 +74,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: 11.7.0
-
+      # npm (not pnpm) on purpose: this is a throwaway VitePress scaffold with no
+      # lockfile, and pnpm 10+ gates dependency build scripts behind an allowlist
+      # whose setting keeps getting renamed (onlyBuiltDependencies -> allowBuilds),
+      # repeatedly breaking esbuild's postinstall here. npm runs build scripts by
+      # default, so it is immune to pnpm version churn.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
@@ -91,8 +92,7 @@ jobs:
             "private": true,
             "type": "module",
             "scripts": { "build": "vitepress build docs" },
-            "devDependencies": { "vitepress": "^1.6.4" },
-            "pnpm": { "onlyBuiltDependencies": ["esbuild"] }
+            "devDependencies": { "vitepress": "^1.6.4" }
           }
           EOF
           cat > docs/.vitepress/config.mts << 'EOF'
@@ -115,8 +115,8 @@ jobs:
       - name: Build
         working-directory: .vitepress-check
         run: |
-          pnpm install --frozen-lockfile || pnpm install
-          pnpm build
+          npm install --no-audit --no-fund
+          npm run build
 
       - name: Generate summary
         if: always()


### PR DESCRIPTION
The shared `docs-check.yml` VitePress build has broken repeatedly because **pnpm 10+ gates dependency build scripts** behind an allowlist whose setting keeps getting **renamed** — `onlyBuiltDependencies` (package.json) → `onlyBuiltDependencies` (pnpm-workspace.yaml) → **`allowBuilds`** (pnpm 11). Each rename re-blocked esbuild postinstall → `ERR_PNPM_IGNORED_BUILDS` → red Docs across 7 repos.

**Fix:** drop pnpm from this throwaway, lockfile-less scaffold and use **npm**, which runs build scripts by default and is immune to pnpm version churn.

Validated 3 ways: local repro, [pnpm v11 notes](https://pnpm.io/blog/releases/11.0) confirming the `allowBuilds` rename, and a real CI run of this reusable workflow → VitePress Build green (no `ERR_PNPM`).