### PR TITLE
feat(ci): org-level ADPP compatibility matrix (0F)

### DIFF
--- a/.github/workflows/adpp-compat-matrix.yml
+++ b/.github/workflows/adpp-compat-matrix.yml
@@ -1,0 +1,70 @@
+name: ADPP Compatibility Matrix
+
+# Org-level, scheduled, NON-GATING compatibility matrix (anolis-protocol#28).
+#
+# Crosses released anolis-protocol conformance-harness versions with released
+# provider versions and runs the conformance harness for each pair, to surface
+# cross-version drift that no single repo's PR CI can see (a provider lane only
+# checks its own commit against one pinned harness). Report-only: results go to
+# the job summary + an artifact; the workflow never fails on a conformance
+# result. It must never gate a protocol or provider PR.
+#
+# The eligible cell set is discovered at run time (scripts/adpp_compat_*.sh), so
+# this self-activates as new released versions land — no edits needed per release.
+
+on:
+  schedule:
+    - cron: "0 5 * * 0" # Sundays 05:00 UTC (clear of the Mon 06/07/09 org scans)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adpp-compat-matrix
+  cancel-in-progress: false
+
+jobs:
+  matrix:
+    name: Released protocol × released provider
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Enumerate eligible (protocol × provider) cells
+        id: enum
+        run: |
+          scripts/adpp_compat_enumerate.sh > cells.json
+          count="$(jq 'length' cells.json)"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Discovered $count cell(s):"
+          jq -c '.[]' cells.json || true
+
+      - name: Run conformance harness for each cell
+        if: steps.enum.outputs.count != '0'
+        run: scripts/adpp_compat_run.sh cells.json results.json
+
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ -f results.json ]; then
+            scripts/adpp_compat_summary.sh results.json >> "$GITHUB_STEP_SUMMARY"
+          else
+            scripts/adpp_compat_summary.sh /dev/null >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: adpp-compat-matrix
+          path: |
+            cells.json
+            results.json
+          if-no-files-found: ignore
+          retention-days: 90

--- a/scripts/adpp_compat_enumerate.sh
+++ b/scripts/adpp_compat_enumerate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# adpp_compat_enumerate.sh — emit the ADPP compatibility-matrix cell set as JSON.
+#
+# The org-level compatibility matrix (anolis-protocol#28) crosses RELEASED
+# protocol harness versions with RELEASED provider versions and runs the
+# conformance harness for each pair. This script discovers the eligible cells:
+#
+#   protocol axis : anolis-protocol releases >= the conformance floor (v1.3.0,
+#                   the first release shipping the anolis_conformance harness).
+#   provider axis : the latest MAX_PER_PROVIDER releases of each provider whose
+#                   tag bundles config/conformance.toml (the harness manifest).
+#                   Releases predating the manifest are skipped, so the matrix
+#                   self-activates as conformant releases land.
+#
+# Output (stdout): a compact JSON array of
+#   { protocol, protocol_ver, provider, version, ver }
+# Requires: gh (authenticated), jq.
+set -euo pipefail
+
+ORG="anolishq"
+FLOOR="1.3.0"
+PROVIDERS=(anolis-provider-ezo anolis-provider-sim anolis-provider-bread)
+MAX_PER_PROVIDER="${MAX_PER_PROVIDER:-5}"
+
+# --- protocol axis: releases at or above the conformance floor ---
+protocols=()
+while IFS= read -r t; do
+  v="${t#v}"
+  if [ "$(printf '%s\n%s\n' "$FLOOR" "$v" | sort -V | head -1)" = "$FLOOR" ]; then
+    protocols+=("$t")
+  fi
+done < <(gh release list -R "$ORG/anolis-protocol" --limit 50 --json tagName --jq '.[].tagName')
+
+# --- provider axis x protocol axis: one cell per (eligible release, protocol) ---
+cells='[]'
+for repo in "${PROVIDERS[@]}"; do
+  while IFS= read -r vt; do
+    # eligible only if the tag bundles the conformance manifest
+    if gh api "repos/$ORG/$repo/contents/config/conformance.toml?ref=$vt" >/dev/null 2>&1; then
+      for pt in "${protocols[@]}"; do
+        cells=$(jq -c \
+          --arg protocol "$pt" --arg protocol_ver "${pt#v}" \
+          --arg provider "$repo" --arg version "$vt" --arg ver "${vt#v}" \
+          '. += [{protocol:$protocol, protocol_ver:$protocol_ver, provider:$provider, version:$version, ver:$ver}]' \
+          <<<"$cells")
+      done
+    fi
+  done < <(gh release list -R "$ORG/$repo" --limit "$MAX_PER_PROVIDER" --json tagName --jq '.[].tagName')
+done
+
+echo "$cells"

--- a/scripts/adpp_compat_run.sh
+++ b/scripts/adpp_compat_run.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# adpp_compat_run.sh <cells.json> <results.json>
+#
+# Runs the ADPP conformance harness for every (protocol, provider, version) cell
+# produced by adpp_compat_enumerate.sh and writes a results array:
+#   { protocol, provider, version, status: pass|fail, rc, summary }
+#
+# Per cell: install the protocol's conformance harness wheel (cached per
+# protocol), download the provider's released linux-x86_64 binary + source
+# tarball (cached per provider@version), then run the harness against the
+# released binary using the released manifest + mock config. Never fails the
+# job on a conformance failure — the result is recorded, not gated.
+#
+# Requires: gh (authenticated), jq, python3.
+set -euo pipefail
+
+CELLS="${1:?usage: adpp_compat_run.sh <cells.json> <results.json>}"
+OUT="${2:?usage: adpp_compat_run.sh <cells.json> <results.json>}"
+ORG="anolishq"
+
+WORK="$(mktemp -d)"
+VENVS="$WORK/venvs"
+ART="$WORK/art"
+mkdir -p "$VENVS" "$ART"
+trap 'rm -rf "$WORK"' EXIT
+
+# Install (once per protocol) the conformance harness from its release wheel;
+# echo the path to the cell's anolis-adpp-conformance entry point.
+ensure_harness() {
+  local tag="$1" ver="${1#v}" venv="$VENVS/$1"
+  if [ ! -x "$venv/bin/anolis-adpp-conformance" ]; then
+    python3 -m venv "$venv" >&2
+    "$venv/bin/pip" install --quiet --upgrade pip >&2
+    "$venv/bin/pip" install --quiet \
+      "anolis-protocol[conformance] @ https://github.com/$ORG/anolis-protocol/releases/download/$tag/anolis_protocol-$ver-py3-none-any.whl" >&2
+  fi
+  echo "$venv/bin/anolis-adpp-conformance"
+}
+
+# Download + unpack (once per provider@version) the released binary and source
+# tarball; echo "<binary path>|<config dir>".
+ensure_provider() {
+  local repo="$1" ver="$2" d="$ART/$1@$2"
+  if [ ! -d "$d" ]; then
+    mkdir -p "$d/bin" "$d/cfg"
+    gh release download "$ver" -R "$ORG/$repo" --pattern '*linux-x86_64.tar.gz' --dir "$d" >&2
+    gh release download "$ver" -R "$ORG/$repo" --pattern '*source.tar.gz' --dir "$d" >&2
+    tar xzf "$d"/*linux-x86_64.tar.gz -C "$d/bin"
+    tar xzf "$d"/*source.tar.gz -C "$d/cfg" --strip-components=1
+  fi
+  local bin
+  bin="$(find "$d/bin" -type f -name "$repo")"
+  echo "$bin|$d/cfg"
+}
+
+results='[]'
+n="$(jq 'length' "$CELLS")"
+for i in $(seq 0 $((n - 1))); do
+  cell="$(jq -c ".[$i]" "$CELLS")"
+  protocol="$(jq -r '.protocol' <<<"$cell")"
+  repo="$(jq -r '.provider' <<<"$cell")"
+  version="$(jq -r '.version' <<<"$cell")"
+
+  harness="$(ensure_harness "$protocol")"
+  IFS='|' read -r bin cfg < <(ensure_provider "$repo" "$version")
+
+  set +e
+  out="$("$harness" \
+    --provider-bin "$bin" \
+    --provider-config "$cfg/config/conformance.yaml" \
+    --provider-profile "$cfg/config/conformance.toml" \
+    -ra 2>&1)"
+  rc=$?
+  set -e
+
+  # Three outcomes, distinguished so a harness-side incompatibility is never
+  # mislabeled as a provider conformance failure:
+  #   pass  - harness ran and every selected assertion passed (rc 0).
+  #   fail  - harness ran and reported failing/erroring assertions: the provider
+  #           genuinely violates the contract for that protocol version.
+  #   error - harness could not produce a verdict (e.g. a pytest INTERNALERROR,
+  #           or every test deselected) - a harness/version-compat problem, not a
+  #           provider defect. Older harnesses error out against newer providers.
+  if [ "$rc" -eq 0 ]; then
+    status="pass"
+  elif grep -qE '[1-9][0-9]* (failed|error)' <<<"$out"; then
+    status="fail"
+  else
+    status="error"
+  fi
+  line="$(grep -hoE '[0-9]+ (passed|failed|skipped|error|deselected|xfailed)[^=]*' <<<"$out" | tail -1 | sed -E 's/ +$//')"
+  [ -n "$line" ] || line="(no harness summary; rc=$rc)"
+
+  results="$(jq -c \
+    --arg p "$protocol" --arg r "$repo" --arg v "$version" \
+    --arg s "$status" --arg l "$line" --argjson rc "$rc" \
+    '. += [{protocol:$p, provider:$r, version:$v, status:$s, rc:$rc, summary:$l}]' \
+    <<<"$results")"
+  echo "[$status] $protocol x $repo $version :: $line" >&2
+done
+
+echo "$results" >"$OUT"

--- a/scripts/adpp_compat_summary.sh
+++ b/scripts/adpp_compat_summary.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# adpp_compat_summary.sh <results.json>
+#
+# Render the ADPP compatibility-matrix results (from adpp_compat_run.sh) as a
+# GitHub-flavored markdown table on stdout (intended for $GITHUB_STEP_SUMMARY).
+# Report-only: prints a status table, never exits non-zero on conformance fails.
+set -euo pipefail
+
+R="${1:?usage: adpp_compat_summary.sh <results.json>}"
+
+echo "## ADPP Compatibility Matrix"
+echo
+echo "Released protocol harness × released provider — conformance harness run per"
+echo "cell. Non-gating; report-only (anolis-protocol#28)."
+echo
+
+if [ ! -s "$R" ] || [ "$(jq 'length' "$R")" = "0" ]; then
+  echo "_No eligible (protocol × provider) cells yet — no released provider bundles"
+  echo "\`config/conformance.toml\` against a protocol harness ≥ v1.3.0._"
+  exit 0
+fi
+
+total="$(jq 'length' "$R")"
+passed="$(jq '[.[]|select(.status=="pass")]|length' "$R")"
+failed="$(jq '[.[]|select(.status=="fail")]|length' "$R")"
+errored="$(jq '[.[]|select(.status=="error")]|length' "$R")"
+
+line="**$passed/$total passed.**"
+[ "$failed" -gt 0 ] && line="$line ❌ $failed failed."
+[ "$errored" -gt 0 ] && line="$line ⚠️ $errored no-verdict."
+echo "$line"
+echo
+echo "Legend: ✅ pass · ❌ provider violates the contract for that protocol ·"
+echo "⚠️ harness produced no verdict (version incompatibility, e.g. an older"
+echo "harness erroring against a newer provider) — _not_ a provider failure · – not run."
+echo
+
+# Columns = protocol versions; rows = provider @ version.
+mapfile -t protos < <(jq -r '[.[].protocol]|unique|sort|.[]' "$R")
+
+header="| provider @ version |"
+divider="|---|"
+for p in "${protos[@]}"; do
+  header+=" $p |"
+  divider+="---|"
+done
+echo "$header"
+echo "$divider"
+
+while IFS= read -r pv; do
+  prov="${pv%% *}"
+  ver="${pv##* }"
+  row="| \`$prov\` $ver |"
+  for p in "${protos[@]}"; do
+    st="$(jq -r --arg prov "$prov" --arg ver "$ver" --arg p "$p" \
+      'map(select(.provider==$prov and .version==$ver and .protocol==$p))|.[0].status // "na"' "$R")"
+    case "$st" in
+      pass) row+=" ✅ |" ;;
+      fail) row+=" ❌ |" ;;
+      error) row+=" ⚠️ |" ;;
+      *) row+=" – |" ;;
+    esac
+  done
+  echo "$row"
+done < <(jq -r '[.[]|.provider+" "+.version]|unique|.[]' "$R" | sort)
+
+echo
+echo "<details><summary>Per-cell harness summary</summary>"
+echo
+jq -r '.[]|"- \({pass:"✅",fail:"❌",error:"⚠️"}[.status] // "–") `\(.protocol)` × `\(.provider)` \(.version) — \(.summary) (rc=\(.rc))"' "$R"
+echo
+echo "</details>"


### PR DESCRIPTION
Implements **Phase 0F** of the ADPP conformance epic (anolis-protocol#28): an org-level, **scheduled, non-gating** compatibility matrix that crosses released protocol harness versions × released provider versions and runs the conformance harness for each pair.

## Why
A provider's own lane verifies *its current commit* against *one pinned* harness. This answers a different question — does released protocol vX still pass against released provider vY? — which is a scheduled/org concern and must **never** gate a protocol or provider PR.

## How it works
- `scripts/adpp_compat_enumerate.sh` discovers cells at run time: protocol releases ≥ `v1.3.0` (the conformance floor) × the latest provider releases whose tag **bundles `config/conformance.toml`**. Pre-manifest releases are skipped, so the matrix **self-activates** as conformant releases land — no edits per release.
- `scripts/adpp_compat_run.sh` installs each protocol's harness wheel, downloads the released provider binary + source tarball, and runs `anolis-adpp-conformance` against the released artifacts.
- `scripts/adpp_compat_summary.sh` renders a status table to the job summary.
- Workflow: `schedule` (Sun 05:00 UTC) + `workflow_dispatch`, `permissions: contents: read`, report-only (job summary + 90-day artifact), `exit 0` always.

## Three outcomes (important)
Cells are classified **pass / fail / error** so a *harness-side* incompatibility is never mislabeled as a provider conformance failure:
- ✅ **pass** — harness ran, all assertions passed.
- ❌ **fail** — provider genuinely violates the contract for that protocol.
- ⚠️ **error** — harness produced no verdict (e.g. a pytest `INTERNALERROR`, or all-deselected) — a version-compat issue, not a provider defect.

## Validated locally end-to-end against the live releases
Ran the full enumerate→run→summary over the current release set (6 cells). Result:

| provider @ version | v1.3.0 | v1.4.0 |
|---|---|---|
| `anolis-provider-bread` v0.2.11 | ⚠️ | ✅ |
| `anolis-provider-ezo` v0.2.7 | ⚠️ | ✅ |
| `anolis-provider-sim` v0.2.5 | ⚠️ | ✅ |

All three providers pass the current harness (v1.4.0). The **v1.3.0 harness ⚠️** is a real finding the matrix exists to surface: it `INTERNALERROR`s during collection against level-2 providers (fixed in v1.4.0) — flagged as no-verdict, not a provider failure. Scripts are shellcheck-clean.

## Notes / follow-ups
- The new workflow triggers only on schedule/dispatch, so it does **not** run on this PR and cannot gate anything.
- Possible later enhancements: open/update a tracking issue on a real ❌ (the epic mentions "issue or summary on drift"); widen the provider axis beyond `MAX_PER_PROVIDER=5`.
- Relates to the workbench↔matrix reconciliation (shared "released-version source of truth") — separate tracking issue to follow.