### PR TITLE
fix(setup-vcpkg): add cache-write toggle to stop subset builds clobbering the shared binary cache

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -28,6 +28,17 @@ inputs:
     description: "GitHub token (reserved for future NuGet integration)"
     required: false
     default: ${{ github.token }}
+  cache-write:
+    description: >
+      Whether this job may WRITE (save) the vcpkg binary cache. Default "true".
+      Set "false" for a build variant whose dependency closure is a SUBSET of
+      another variant that shares the same cache key (same os/arch/triplet/
+      baseline/manifest) — e.g. a FluxGraph-OFF build alongside a FluxGraph-ON
+      build. A read-only job restores the superset cache but never saves, so the
+      faster subset job cannot clobber the superset cache under the shared key
+      (which would otherwise drop the expensive packages and force rebuilds).
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -67,8 +78,22 @@ runs:
       shell: bash
       run: mkdir -p "${{ github.workspace }}/.vcpkg-binary-cache"
 
-    - name: Restore vcpkg binary cache
+    # Writer jobs (cache-write=true, default) restore AND save the cache.
+    - name: Restore + save vcpkg binary cache (writer)
+      if: inputs.cache-write == 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ github.workspace }}/.vcpkg-binary-cache
+        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
+        restore-keys: |
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-
+
+    # Reader jobs (cache-write=false) restore only — no post-save — so a subset
+    # build cannot overwrite the shared key with an incomplete cache.
+    - name: Restore vcpkg binary cache (read-only)
+      if: inputs.cache-write != 'true'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ github.workspace }}/.vcpkg-binary-cache
         key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
@@ -106,4 +131,6 @@ runs:
       run: |
         set -euo pipefail
         echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> "$GITHUB_ENV"
-        echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-binary-cache,readwrite" >> "$GITHUB_ENV"
+        mode="read"
+        if [[ "${{ inputs.cache-write }}" == "true" ]]; then mode="readwrite"; fi
+        echo "VCPKG_BINARY_SOURCES=clear;files,${{ github.workspace }}/.vcpkg-binary-cache,$mode" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem
The vcpkg binary-cache key is keyed on os/arch/triplet/baseline/manifest but **not** on the build variant. So two jobs that share a triplet but build **different dependency closures** compute the *same* key and both write `readwrite`. They race to save; the faster **subset** job wins the reservation (`Unable to reserve cache ... another job may be creating this cache`), so the persisted cache lacks the expensive packages and the **superset** job rebuilds them every run.

Live example — `anolis-provider-sim`'s Windows lane: FluxGraph-ON (pulls **grpc**) and FluxGraph-OFF (no grpc) share a key; the grpc-less OFF job wins the save, so the Windows cache is stuck at **148 MB (no grpc)** and the ON build rebuilds grpc (**~1.5h**) every run — a ~2h lane. (Linux got lucky: its cache is the full 3.5 GB.)

## Fix
Add an optional **`cache-write`** input (default `"true"` — **unchanged** behavior). When `"false"`:
- restore via `actions/cache/restore` (no post-save) instead of `actions/cache`, and
- set `VCPKG_BINARY_SOURCES` to `...,read`.

So a subset variant **reads** the superset cache but never **clobbers** it under the shared key.

## Backward compatibility
Callers that don't set `cache-write` (ezo, bread, and sim's writer jobs) are byte-for-byte identical to before — the writer path is unchanged. Only jobs that opt in with `cache-write: false` change.

## Rollout
After merge + the `v2` tag moves here, `anolis-provider-sim` will set `cache-write: false` on its FluxGraph-OFF (subset) jobs and the stuck partial Windows caches will be deleted so the first ON run repopulates a complete one. ezo/bread unaffected.