### PR TITLE
fix(setup-vcpkg): image-aware vcpkg binary-cache key

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -78,14 +78,25 @@ runs:
       shell: bash
       run: mkdir -p "${{ github.workspace }}/.vcpkg-binary-cache"
 
+    # The key embeds the runner ImageVersion (`img<version>`) because vcpkg's
+    # per-package ABI hash includes the compiler hash. When GitHub bumps the
+    # runner image (and with it MSVC/gcc), the old binary archives become ABI
+    # mismatches ("Restored 0 packages") and vcpkg rebuilds from source. Without
+    # the image in the key, the manifest-hash key still hits exactly, so
+    # actions/cache skips the post-save and the rebuilt archives are never
+    # persisted — making the rebuild permanent (observed: anolis Windows ~34min
+    # every run after an MSVC bump). Embedding ImageVersion rotates the key when
+    # the image changes, forcing a fresh save; the bare-prefix restore-keys still
+    # seed from a prior image so only the drifted packages rebuild.
     # Writer jobs (cache-write=true, default) restore AND save the cache.
     - name: Restore + save vcpkg binary cache (writer)
       if: inputs.cache-write == 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ github.workspace }}/.vcpkg-binary-cache
-        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
+        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-img${{ env.ImageVersion }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
         restore-keys: |
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-img${{ env.ImageVersion }}-
           vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-
           vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-
 
@@ -96,8 +107,9 @@ runs:
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ${{ github.workspace }}/.vcpkg-binary-cache
-        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
+        key: vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-img${{ env.ImageVersion }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-configuration.json', '**/triplets/**') }}
         restore-keys: |
+          vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-img${{ env.ImageVersion }}-
           vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-${{ steps.resolve.outputs.commit }}-
           vcpkg-bin-${{ runner.os }}-${{ runner.arch }}-${{ inputs.triplet }}-
 


### PR DESCRIPTION
## Problem

vcpkg's per-package ABI hash includes the **compiler hash**. When a GitHub runner image bumps the toolchain (e.g. MSVC on `windows-2025`), every cached binary archive becomes an ABI mismatch.

The old cache key was `vcpkg-bin-<os>-<arch>-<triplet>-<commit>-<hashFiles(vcpkg.json…)>` — **no compiler/image dimension**. Because `vcpkg.json` rarely changes, the key keeps hitting **exactly** after a toolchain bump. actions/cache skips the post-save on an exact hit, so the freshly rebuilt (current-toolchain) archives are **never persisted** → the from-source rebuild recurs on *every* run.

### Evidence (anolis Windows, run 27927894449)
- actions/cache: `Cache restored successfully ~396 MB` (exact hit)
- vcpkg: `Restored 0 package(s)` → rebuilds all 35 from source (~34 min, behaviortree-cpp → boost/zeromq/flatbuffers)
- compiler: `MSVC 19.51.36247` / toolset `14.51.36231`, image `win25/20260614` — newer than the 06-16 cache
- Linux (gcc, stable) on the same runs: `Restored 39 package(s)` → ~3 min. Unaffected.

## Fix

Embed the runner `ImageVersion` (`img<version>`) in the key, and add a bare-`<commit>-` restore-key tier:

```
key:          vcpkg-bin-<os>-<arch>-<triplet>-<commit>-img<ImageVersion>-<hashFiles>
restore-keys: vcpkg-bin-<os>-<arch>-<triplet>-<commit>-img<ImageVersion>-
              vcpkg-bin-<os>-<arch>-<triplet>-<commit>-
              vcpkg-bin-<os>-<arch>-<triplet>-
```

When the image changes, the exact key rotates → cache miss → restore-keys seed from a prior image (only ABI-drifted packages rebuild) → exact key missed → **post-save runs**, persisting a fresh cache. Stable-image runs are unchanged. Orthogonal to the `cache-write` clobber toggle (v2.1).

First run per repo after adopting this does a one-time rebuild as the key rotates, then warms.

Found via a cross-repo CI-time audit (anolis#80).