### PR TITLE
feat(templates): shared lint/format configs for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ Shared markdownlint configuration fetched by `docs-check.yml`:
 - Line length: 140 (relaxed for technical docs)
 - MD033 disabled (allows inline HTML for VitePress components)
 
+### Provider lint/format templates
+
+Shared C++ formatting/lint config for the device providers (ezo/sim/bread), kept
+consistent with the anolis runtime. Copy each into the consumer repo root:
+
+| Template | Copy to | Purpose |
+| --- | --- | --- |
+| `templates/clang-format` | `.clang-format` | clang-format 18 style (Google base, 120 cols, 4-space indent). Gate in CI with `clang-format --dry-run --Werror`. |
+| `templates/clang-tidy` | `.clang-tidy` | High-signal checks (diagnostic/analyzer/bugprone/performance; readability off). Adjust `HeaderFilterRegex` to the repo's source roots. |
+| `templates/editorconfig` | `.editorconfig` | Editor defaults aligned with `.clang-format` (4-space C++, LF, trim trailing). |
+| `templates/provider.justfile` | `justfile` | Task runner (`setup`, `fmt`, `fmt-check`, `lint`, `check`, `test`). Set `preset` to the repo's primary CMake preset. |
+
+The CI format gate mirrors the runtime's `C++ Formatting (clang-format)` job —
+install `clang-format` on `ubuntu-24.04` (→ v18) and run `--dry-run --Werror`
+over the tracked C++ sources.
+
 ## Dependency scanning
 
 `dependency-scan.yml` is a reusable workflow that scans a repo's **vcpkg**

--- a/templates/clang-format
+++ b/templates/clang-format
@@ -1,0 +1,7 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+ColumnLimit: 120
+IndentWidth: 4
+AccessModifierOffset: -4
+...

--- a/templates/clang-tidy
+++ b/templates/clang-tidy
@@ -1,0 +1,20 @@
+---
+# Shared provider clang-tidy config (mirrors the anolis runtime).
+# High-value signal only: keep diagnostics/analyzer/bugprone/performance, drop readability noise.
+Checks: >
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  performance-*,
+  bugprone-*,
+  -readability-*,
+  -bugprone-macro-parentheses,
+  -bugprone-easily-swappable-parameters
+# Note: consider re-enabling specific readability checks once bugprone/perf are clean.
+WarningsAsErrors: ""
+# Limit diagnostics to the repo's own source roots. ADJUST per provider to match
+# its layout (e.g. "src", "include", "tests"); this default covers the common case.
+# Generated protobuf sources live under build/ and are excluded — also disable
+# clang-tidy on the protobuf CMake target so compile_commands does not drag them in.
+HeaderFilterRegex: ".*/(src|include|tests)/.*"
+FormatStyle: file
+...

--- a/templates/editorconfig
+++ b/templates/editorconfig
@@ -1,0 +1,32 @@
+# Shared editor defaults for anolis providers. Copy to `.editorconfig` at the repo root.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+# C/C++ — matches .clang-format (IndentWidth: 4)
+[*.{c,cc,cpp,cxx,h,hh,hpp,hxx}]
+indent_size = 4
+
+[*.{cmake,txt}]
+indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 2
+
+[*.{yml,yaml,json}]
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[justfile]
+indent_size = 4
+
+# Markdown — keep trailing whitespace (hard line breaks)
+[*.md]
+trim_trailing_whitespace = false

--- a/templates/provider.justfile
+++ b/templates/provider.justfile
@@ -1,0 +1,38 @@
+# Shared task runner for anolis providers. Copy to `justfile` at the repo root and
+# set `preset` to the repo's primary CMake configure/test preset.
+#
+# Standard recipes (match the org convention): setup, fmt, fmt-check, lint, check, test.
+
+# Primary CMake preset — override per repo (e.g. ci-linux-release).
+preset := "ci-linux-release"
+
+# C++ sources tracked by git (excludes generated build/ output).
+cpp_files := "git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx'"
+
+# List available recipes.
+default:
+    @just --list
+
+# Configure (vcpkg deps resolve during CMake configure).
+setup:
+    cmake --preset {{preset}}
+
+# Format C++ sources in place (clang-format 18).
+fmt:
+    {{cpp_files}} | xargs clang-format -i
+
+# Verify formatting without modifying files (CI gate).
+fmt-check:
+    {{cpp_files}} | xargs clang-format --dry-run --Werror
+
+# Static analysis over the compile database (requires a configured build dir).
+lint:
+    run-clang-tidy -p build/{{preset}} $({{cpp_files}})
+
+# CI-equivalent: formatting + lint.
+check: fmt-check lint
+
+# Build and run the test suite.
+test:
+    cmake --build --preset {{preset}} --parallel
+    ctest --preset {{preset}} --output-on-failure


### PR DESCRIPTION
Adds copy-into-consumer templates so the providers (ezo/sim/bread) get consistent C++ formatting/lint config, matching the anolis runtime:

- `templates/clang-format` → `.clang-format` (clang-format 18; Google base, 120 cols, 4-space)
- `templates/clang-tidy` → `.clang-tidy` (high-signal checks; adjust `HeaderFilterRegex` per repo)
- `templates/editorconfig` → `.editorconfig`
- `templates/provider.justfile` → `justfile` (setup/fmt/fmt-check/lint/check/test)

Documented under **Shared Configuration** in the README. First half of #63; provider adoption (configs + CI format gate) follows per repo.