### PR TITLE
docs(templates): pipx-pinned clang-format gate + pre-commit note

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,18 @@ consistent with the anolis runtime. Copy each into the consumer repo root:
 | `templates/editorconfig` | `.editorconfig` | Editor defaults aligned with `.clang-format` (4-space C++, LF, trim trailing). |
 | `templates/provider.justfile` | `justfile` | Task runner (`setup`, `fmt`, `fmt-check`, `lint`, `check`, `test`). Set `preset` to the repo's primary CMake preset. |
 
-The CI format gate mirrors the runtime's `C++ Formatting (clang-format)` job —
-install **`clang-format-18`** on `ubuntu-24.04` and run `clang-format-18
---dry-run --Werror` over the tracked C++ sources. Pin the versioned package: the
-unversioned `clang-format` on `ubuntu-24.04` resolves to an experimental 18.0
-snapshot (`1:18.0-59~exp2`) that formats some constructs differently from the
-stable 18.1.8 (`clang-format-18`), so an unpinned gate is non-deterministic.
-Locally, match it with `clang-format-18` or `pipx run clang-format==18.1.8`.
+The CI format gate runs the **exact** clang-format via the PyPI wheel —
+`xargs pipx run clang-format==18.1.8 --dry-run --Werror` over the tracked C++
+sources. Pin the wheel rather than an apt package: `apt` versions drift by
+distro/image (unversioned `clang-format` on `ubuntu-24.04` is an experimental
+18.0 snapshot; `clang-format-18` is 18.1.3 there but 18.1.8 on Debian), and
+18.1.3 vs 18.1.8 wrap long operator chains differently — so an apt-based gate is
+non-deterministic. The PyPI wheel is byte-identical everywhere; match it locally
+with the same `pipx run clang-format==18.1.8`.
+
+> This per-repo inline gate is an interim measure. The planned org-wide source of
+> truth is a shared **pre-commit** config (pinned hooks, enforced locally and in
+> CI) — see [#69](https://github.com/anolishq/.github/issues/69).
 
 ## Dependency scanning
 


### PR DESCRIPTION
Update the Shared Configuration docs: the format gate runs `pipx run clang-format==18.1.8` (exact PyPI wheel, byte-identical everywhere) instead of an apt package that drifts by distro (18.1.3 on ubuntu-24.04 vs 18.1.8 on Debian). Cross-references the planned org-wide pre-commit rollout (#69). Finishes the doc side of #63.