### PR TITLE
feat(templates): add shared pinned pre-commit config (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,18 @@ consistent with the anolis runtime. Copy each into the consumer repo root:
 | `templates/clang-format` | `.clang-format` | clang-format 18 style (Google base, 120 cols, 4-space indent). Gate in CI with `clang-format --dry-run --Werror`. |
 | `templates/clang-tidy` | `.clang-tidy` | High-signal checks (diagnostic/analyzer/bugprone/performance; readability off). Adjust `HeaderFilterRegex` to the repo's source roots. |
 | `templates/editorconfig` | `.editorconfig` | Editor defaults aligned with `.clang-format` (4-space C++, LF, trim trailing). |
-| `templates/provider.justfile` | `justfile` | Task runner (`setup`, `fmt`, `fmt-check`, `lint`, `check`, `test`). Set `preset` to the repo's primary CMake preset. |
+| `templates/pre-commit-config.yaml` | `.pre-commit-config.yaml` | **Pinned formatter source of truth.** `mirrors-clang-format@v18.1.8` — the same PyPI wheel, run identically by devs (`pre-commit install`) and CI (`pre-commit run --all-files`). |
+| `templates/provider.justfile` | `justfile` | Task runner (`setup`, `hooks`, `fmt`, `fmt-check`, `lint`, `check`, `test`). `fmt`/`fmt-check` delegate to pre-commit. Set `preset` to the repo's primary CMake preset. |
 
-The CI format gate runs the **exact** clang-format via the PyPI wheel —
-`xargs pipx run clang-format==18.1.8 --dry-run --Werror` over the tracked C++
-sources. Pin the wheel rather than an apt package: `apt` versions drift by
-distro/image (unversioned `clang-format` on `ubuntu-24.04` is an experimental
-18.0 snapshot; `clang-format-18` is 18.1.3 there but 18.1.8 on Debian), and
-18.1.3 vs 18.1.8 wrap long operator chains differently — so an apt-based gate is
-non-deterministic. The PyPI wheel is byte-identical everywhere; match it locally
-with the same `pipx run clang-format==18.1.8`.
+The formatter is pinned **in-repo** via pre-commit (`.pre-commit-config.yaml`),
+so the exact clang-format version is consumed identically at commit time and in
+CI — the CI gate is a `pre-commit` job running `pre-commit run --all-files`. Pin
+the wheel rather than an apt package: `apt` versions drift by distro/image
+(unversioned `clang-format` on `ubuntu-24.04` is an experimental 18.0 snapshot;
+`clang-format-18` is 18.1.3 there but 18.1.8 on Debian), and 18.1.3 vs 18.1.8
+wrap long operator chains differently — so an apt-based gate is non-deterministic.
+The `mirrors-clang-format` hook uses the byte-identical PyPI wheel everywhere.
+This supersedes the interim CI-only `pipx run clang-format==18.1.8` gate.
 
 > This per-repo inline gate is an interim measure. The planned org-wide source of
 > truth is a shared **pre-commit** config (pinned hooks, enforced locally and in

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Shared pre-commit config for anolis providers. Copy to `.pre-commit-config.yaml`
+# at the repo root.
+#
+# This is the org's single, pinned source of truth for C++ formatting. The
+# clang-format version is pinned to the exact PyPI wheel (v18.1.8), consumed
+# identically by every dev and by CI — superseding the inline
+# `pipx run clang-format==18.1.8` gate (anolishq/.github#69).
+#
+# Dev:  `pre-commit install` once per clone -> every commit auto-runs the hooks.
+#       (or `just hooks`)
+# CI:   `pre-commit run --all-files` (see the `pre-commit` job in ci.yml).
+#
+# Keep `rev` in lockstep with `templates/clang-format`'s target version. Bump via
+# `pre-commit autoupdate` and reformat the tree in the same change.
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]

--- a/templates/provider.justfile
+++ b/templates/provider.justfile
@@ -17,13 +17,17 @@ default:
 setup:
     cmake --preset {{preset}}
 
-# Format C++ sources in place (clang-format 18).
-fmt:
-    {{cpp_files}} | xargs clang-format -i
+# Install the pinned pre-commit hooks (one-time per clone).
+hooks:
+    pre-commit install
 
-# Verify formatting without modifying files (CI gate).
+# Format C++ sources in place via the pinned pre-commit clang-format.
+fmt:
+    pre-commit run clang-format --all-files
+
+# Verify formatting via the pinned pre-commit hooks (CI gate).
 fmt-check:
-    {{cpp_files}} | xargs clang-format --dry-run --Werror
+    pre-commit run --all-files
 
 # Static analysis over the compile database (requires a configured build dir).
 lint:


### PR DESCRIPTION
Phase 1 of #69 — the shared, pinned pre-commit config as the org formatter source of truth.

## Changes
- **`templates/pre-commit-config.yaml`** (new) — `mirrors-clang-format@v18.1.8`, the same PyPI wheel devs and CI both run.
- **`templates/provider.justfile`** — add a `hooks` recipe (`pre-commit install`); `fmt`/`fmt-check` now delegate to pre-commit.
- **`README.md`** — document the template and the `pre-commit run --all-files` CI gate; note it supersedes the interim CI-only `pipx run clang-format==18.1.8` gate (#63).

## Validated
`pre-commit 4.2.0` + this config runs **clean (zero diff)** on the formatted ezo tree.

## Next (Phase 2, separate PRs per repo)
Each provider (ezo/sim/bread) + the anolis runtime: add `.pre-commit-config.yaml`, swap the bespoke `cpp-format` CI step for a `pre-commit` job, drop the inline pipx gate. Tracked in #69.