### PR TITLE
ci(clang-tidy-diff): add optional apt-packages input

### DIFF
--- a/.github/workflows/clang-tidy-diff.yml
+++ b/.github/workflows/clang-tidy-diff.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: false
         type: boolean
+      apt-packages:
+        description: "Extra apt packages to install before configuring (e.g. a preset's build deps like graphviz). Space-separated; empty by default."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -54,9 +59,12 @@ jobs:
           fetch-depth: 0 # need the PR base for the changed-lines diff
 
       - name: Install build tools
+        env:
+          EXTRA_APT: ${{ inputs.apt-packages }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build g++ pkg-config
+          # shellcheck disable=SC2086
+          sudo apt-get install -y ninja-build g++ pkg-config $EXTRA_APT
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:


### PR DESCRIPTION
Adds an optional, space-separated \`apt-packages\` input to the reusable \`clang-tidy-diff.yml\` gate (empty by default → **no effect on the 4 existing callers**).

## Why
fluxgraph’\s clang-tidy gate currently uses \`ci-linux-release-server\`, which omits the diagram-tool / examples C++ from \`compile_commands.json\`. The caller’\s \`paths\` filter still matches those files, so the gate *claims* to lint them but cannot — a silent coverage gap (false green). Closing that gap needs a max-feature \`ci-linux-tidy\` preset that also builds the diagram tool, which needs the \`graphviz\` apt package at build time.

This input lets a caller install its preset’\s extra build deps before configure, so the gate can build the full feature surface and lint all shipped C++.

## Change
- New optional input \`apt-packages\` (default \`""\`).
- \`Install build tools\` appends it to the apt install line (quoted via env, SC2086-annotated).

Backward-compatible: existing callers pass nothing → identical behavior. Follow-up fluxgraph PR adds \`ci-linux-tidy\` + passes \`apt-packages: graphviz\` and re-pins to this SHA.

Part of anolishq/.github#74 (gate rollout).